### PR TITLE
change markdown library to kramed

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "coffee-script": "~1.8.0",
     "marked": "~0.3.2",
     "nomnom": "~1.8.0",
-    "fs-extra": "~0.12.0"
+    "fs-extra": "~0.12.0",
+    "kramed": "~0.5.5"
   }
 }

--- a/src/exporter.coffee
+++ b/src/exporter.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs-extra'
 sysPath = require 'path'
-marked = require 'marked'
+kramed = require 'kramed'
 
 TEMPLATE_DIR = sysPath.join(__dirname, 'template')
 HTML_TEMPLATE_FILE = sysPath.join(TEMPLATE_DIR, 'index.html')
@@ -21,7 +21,7 @@ exportNoteAsHTML = (noteDir, outputDir) ->
       when 'code'
         s += "<pre class='cell code-cell'><code>#{htmlEscape(c.data)}</code></pre>"
       when 'markdown'
-        s += "<div class='cell markdown-cell'>#{marked(c.data)}</div>"
+        s += "<div class='cell markdown-cell'>#{kramed(c.data)}</div>"
       when 'latex'
         s += "<div class='cell latex-cell'>#{c.data}</div>"
   html = HTML_TEMPLATE.replace('{{title}}', title).replace('{{content}}', s)


### PR DESCRIPTION
Kramdown syntax provide a better support for latex block in markdown language. GitHub Pages and Jekyll have good support for kramdown, too.

[Kramed](https://www.npmjs.com/package/kramed) is a compatible JavaScript implementation of the ruby gem Kramdown.
