### PR TITLE
Load Scripts and Stylesheets via HTTPS & Markdown Images

### DIFF
--- a/src/exporter.coffee
+++ b/src/exporter.coffee
@@ -21,7 +21,7 @@ exportNoteAsHTML = (noteDir, outputDir) ->
       when 'code'
         s += "<pre class='cell code-cell'><code>#{htmlEscape(c.data)}</code></pre>"
       when 'markdown'
-        s += "<div class='cell markdown-cell'>#{marked(c.data)}</div>"
+        s += "<div class='cell markdown-cell'>#{marked(c.data.replace(/quiver-image-url/gi, 'resources'))}</div>"
       when 'latex'
         s += "<div class='cell latex-cell'>#{c.data}</div>"
   html = HTML_TEMPLATE.replace('{{title}}', title).replace('{{content}}', s)

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -12,7 +12,7 @@
     .cell {outline:none;min-height:20px;word-wrap:break-word;margin:5px 0;padding:5px 10px;line-height:1.4}
     code {font-size:13px}
   </style>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"></script>
   <script type="text/javascript">
     window.MathJax = {
       tex2jax: {
@@ -25,8 +25,8 @@
       }
     };
   </script>
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
-  <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/docco.min.css">
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/docco.min.css">
   <script>hljs.initHighlightingOnLoad();</script>
 </head>
 <body class="tex2jax_ignore">


### PR DESCRIPTION
If the note HTML is served via HTTPS, none of the external scripts or stylesheets are loaded, because they are "insecure".
Loading content via HTTPS is recommended, even when the page isn't loaded over HTTPS because of Mixed Content problems.

Also, the image URL for images included in Markdown Cells contained the original "quiver-image-url" folder, not the "resources" which is used by the HTML exporter to include note assets.